### PR TITLE
 Add markdown support for ListItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 yarn install
 
 # serve with hot reload at localhost:8080
-yarn start
+yarn serve
 
 # build for production with minification
 yarn build

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "vue": "^2.6.10",
     "vue-moment": "^4.0.0",
     "vue-router": "^3.0.6",
+    "vue-showdown": "^2.4.1",
     "vuedraggable": "^2.21.0",
     "vuetify": "^1.5.14",
     "vuex": "^3.1.1",

--- a/src/components/editable.vue
+++ b/src/components/editable.vue
@@ -6,6 +6,7 @@
     <div
       ref="contentWrapper"
       class="editable-content" contenteditable="true"
+      @blur="$emit('blur')"
       @input="input" @keyup.enter="update"
       @keydown.enter="disableEvent" @keypress.enter="disableEvent"
     />
@@ -50,6 +51,10 @@ export default {
   },
 
   methods: {
+    focus () {
+      this.$refs.contentWrapper.focus()
+    },
+
     input (event) {
       this.contentText = event.target.innerText
       if (this.saveOnInput) {

--- a/src/components/team/ListItem.vue
+++ b/src/components/team/ListItem.vue
@@ -15,16 +15,22 @@
       </v-list-tile-action>
       <v-list-tile-content>
         <v-list-tile-sub-title>
-          <editable
-            v-if="canWrite"
-            :class="{ checked: item.checked }"
-            :content="item.title"
-            placeholder="Add title..."
-            @update="title = $event"
-          />
-          <div v-else
-               :class="{ checked: item.checked }" >
-            {{ item.title }}
+          <div @click="setEditMode(true)">
+            <editable
+              v-show="editing"
+              ref="editable"
+              :class="{ checked: item.checked }"
+              :content="title"
+              placeholder="Add title..."
+              @blur="setEditMode(false)"
+              @update="title = $event"
+            />
+            <VueShowdown
+              v-show="!editing"
+              :markdown="title"
+              :class="{ checked: item.checked }"
+              flavor="github"
+            />
           </div>
         </v-list-tile-sub-title>
       </v-list-tile-content>
@@ -57,6 +63,12 @@ export default {
     },
   },
 
+  data () {
+    return {
+      editing: false,
+    }
+  },
+
   computed: {
     ...mapGetters(['canWrite']),
 
@@ -70,6 +82,17 @@ export default {
   },
 
   methods: {
+    setEditMode (enabled) {
+      if (!this.canWrite) return
+      this.editing = enabled
+
+      if (enabled) {
+        this.$nextTick(() => {
+          this.$refs.editable.focus()
+        })
+      }
+    },
+
     save () {
       this.$emit('update', this.item)
     },
@@ -90,4 +113,7 @@ export default {
 
 .list .v-list__tile__action .v-input--selection-controls .v-input__slot
     margin: 0 !important
+
+.list .v-list__tile__sub-title p
+    margin: 0
 </style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import '@mdi/font/css/materialdesignicons.css'
 
 import Vue from 'vue'
+import './plugins/vue-showdown'
 import './plugins/vuetify'
 import Vuetify from 'vuetify'
 import './moment'

--- a/src/plugins/vue-showdown.js
+++ b/src/plugins/vue-showdown.js
@@ -1,0 +1,10 @@
+import Vue from 'vue'
+import VueShowdown from 'vue-showdown'
+
+Vue.use(VueShowdown, {
+  flavor: 'github',
+  options: {
+    emoji: true,
+    openLinksInNewWindow: true,
+  },
+})

--- a/tests/unit/components/ListItem.spec.js
+++ b/tests/unit/components/ListItem.spec.js
@@ -1,0 +1,54 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils'
+import Vue from 'vue'
+import Vuex from 'vuex'
+import Vuetify from 'vuetify'
+import editable from '@/components/editable'
+import ListItem from '@/components/team/ListItem'
+
+Vue.use(Vuetify)
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+describe('ListItem', () => {
+  let getters
+  let store
+  let propsData
+
+  beforeEach(() => {
+    getters = {
+      canWrite: jest.fn().mockReturnValue(false),
+    }
+    store = new Vuex.Store({
+      state: {},
+      getters,
+    })
+    propsData = {
+      item: {
+        checked: false,
+        title: '',
+      },
+    }
+  })
+
+  it('renders with no exceptions', () => {
+    shallowMount(ListItem, { propsData, store, localVue })
+  })
+
+  it('doesn\'t have an editable title', () => {
+    let wrapper = shallowMount(ListItem, { propsData, store, localVue })
+    expect(wrapper.find(editable).exists()).toBe(false)
+  })
+
+  describe('canWrite is true', () => {
+    let wrapper
+
+    beforeEach(() => {
+      getters.canWrite.mockReturnValue(true)
+      wrapper = shallowMount(ListItem, { propsData, store, localVue })
+    })
+
+    it('has an editable title', () => {
+      expect(wrapper.find(editable).exists()).toBe(true)
+    })
+  })
+})

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,9 +1,9 @@
 module.exports = {
   chainWebpack: config => {
     config
-      .plugin("define")
+      .plugin('define')
       .tap(args => {
-        Object.assign(args[0]["process.env"], { VUE_APP_VERSION: Date.now() })
+        Object.assign(args[0]['process.env'], { VUE_APP_VERSION: Date.now() })
         return args
       })
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10987,6 +10987,13 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+showdown@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.9.0.tgz#d49d2a0b6db21b7c2e96ef855f7b3b2a28ef46f4"
+  integrity sha512-x7xDCRIaOlicbC57nMhGfKamu+ghwsdVkHMttyn+DelwzuHOx4OHCVL/UW/2QOLH7BxfCcCCVVUix3boKXJKXQ==
+  dependencies:
+    yargs "^10.0.3"
+
 sigmund@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
@@ -12253,6 +12260,13 @@ vue-server-renderer@^2.6.10:
     serialize-javascript "^1.3.0"
     source-map "0.5.6"
 
+vue-showdown@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/vue-showdown/-/vue-showdown-2.4.1.tgz#7cd94597dc1f9ae1286f8a8aab04abfa69b522aa"
+  integrity sha512-bjIadKGnP6XrX41gWL/lKl+7D3t22XXAIPZji/wt0sK32hEK/ejALfN1BSRWcs7oEe+EFOsJG9KRoC+B5HDmnQ==
+  dependencies:
+    showdown "^1.9.0"
+
 vue-style-loader@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-4.1.2.tgz#dedf349806f25ceb4e64f3ad7c0a44fba735fcf8"
@@ -12720,6 +12734,13 @@ yargs-parser@^13.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  integrity sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs-parser@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
@@ -12744,6 +12765,24 @@ yargs@12.0.5:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@^10.0.3:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
+  integrity sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^8.1.0"
 
 yargs@^11.0.0:
   version "11.1.0"


### PR DESCRIPTION
This PR adds _limited_ markdown support for the `ListItem` component. Larger markdown tags such as code and headers are disabled.

### Why?
I've seen teams use the list feature as a wiki for the team. Lack of hyperlinks, bolding and other style attributes affects readability for those who use the list feature extensively.