### PR TITLE
Add support for emoji reactions on list items

### DIFF
--- a/src/components/team/EmojiButton.vue
+++ b/src/components/team/EmojiButton.vue
@@ -1,7 +1,7 @@
 <template>
   <v-btn icon ripple class="emoji-button" @click="handleClick">
     <span class="emoji-button__emoji">{{ emojisByName[this.$props.name] }}</span>
-    <span v-if="showCount" class="emoji-button__count">{{ this.$props.count }}</span>
+    <span v-if="showCount" class="emoji-button__count primary--text">{{ this.$props.count }}</span>
   </v-btn>
 </template>
 

--- a/src/components/team/EmojiButton.vue
+++ b/src/components/team/EmojiButton.vue
@@ -1,0 +1,54 @@
+<template>
+  <v-btn icon ripple class="emoji-button" @click="handleClick">
+    <span class="emoji-button__emoji">{{ emojisByName[this.$props.name] }}</span>
+    <span v-if="showCount" class="emoji-button__count">{{ this.$props.count }}</span>
+  </v-btn>
+</template>
+
+<script>
+import { emojisByName } from '@/lib/emojis'
+
+export default {
+  props: {
+    name: {
+      type: String,
+      required: true,
+    },
+    showCount: {
+      type: Boolean,
+      default: false,
+    },
+    count: {
+      type: Number,
+      default: 0,
+    },
+  },
+
+  data () {
+    return {
+      emojisByName,
+    }
+  },
+
+  methods: {
+    handleClick (event) {
+      if (event.shiftKey) this.$emit('shiftClick')
+      else this.$emit('click')
+    },
+  },
+}
+</script>
+
+<style lang="stylus">
+.emoji-button
+  margin: 0
+  font-style: normal
+  font-weight: normal
+
+  .emoji-button__emoji
+    font-size: 1.2em
+    width: 1.1em
+
+  .emoji-button__count
+    font-size: 0.9em
+</style>

--- a/src/components/team/EmojiPicker.vue
+++ b/src/components/team/EmojiPicker.vue
@@ -1,0 +1,39 @@
+<template>
+  <ul class="emoji-picker background">
+    <li v-for="emojiName in emojiNames" :key="emojiName" class="emoji-picker__item">
+      <EmojiButton :name="emojiName" @click="pick(emojiName)"/>
+    </li>
+  </ul>
+</template>
+
+<script>
+import EmojiButton from '@/components/team/EmojiButton'
+import { emojiNames } from '@/lib/emojis'
+
+export default {
+  components: {
+    EmojiButton,
+  },
+
+  data () {
+    return {
+      emojiNames,
+    }
+  },
+
+  methods: {
+    pick (emojiName) {
+      this.$emit('pick', emojiName)
+    },
+  },
+}
+</script>
+
+<style lang="stylus">
+.emoji-picker
+  padding: 8px
+
+  .emoji-picker__item
+    list-style-type: none
+    display: inline-block
+</style>

--- a/src/components/team/List.vue
+++ b/src/components/team/List.vue
@@ -22,7 +22,7 @@
       </v-btn>
     </v-subheader>
 
-    <draggable v-model="items" :options="{ handle: '.inner-handle' }">
+    <draggable v-model="items" handle=".inner-handle">
       <template v-for="item in items">
         <ListItem :item="item" :key="item['.key']"
                   :loading="isLoading(item['.key'])" @update="updateItem"

--- a/src/components/team/ListItem.vue
+++ b/src/components/team/ListItem.vue
@@ -46,7 +46,6 @@
           </li>
         </ul>
       </v-list-tile-content>
-      <v-progress-circular v-if="loading" indeterminate color="primary"/>
       <v-list-tile-action v-if="canWrite">
         <v-menu>
           <v-btn slot="activator" icon ripple class="add-emoji">
@@ -55,7 +54,10 @@
           <EmojiPicker @pick="addEmoji($event)"/>
         </v-menu>
       </v-list-tile-action>
-      <v-list-tile-action v-if="canWrite">
+      <v-list-tile-action v-if="loading">
+        <v-progress-circular indeterminate color="grey lighten-1" size="24"/>
+      </v-list-tile-action>
+      <v-list-tile-action v-else-if="canWrite">
         <v-btn icon ripple class="remove-item" @click="remove">
           <v-icon color="grey lighten-1">close</v-icon>
         </v-btn>

--- a/src/components/team/Lists.vue
+++ b/src/components/team/Lists.vue
@@ -15,7 +15,7 @@
         </v-btn>
       </v-toolbar>
       <v-list class="pl-2" three-line>
-        <draggable v-model="lists" :options="{ handle: '.outer-handle' }">
+        <draggable v-model="lists" handle=".outer-handle">
           <template v-for="list in lists">
             <List :list="list" :key="list['.key']" />
           </template>

--- a/src/components/team/PersonDialog.vue
+++ b/src/components/team/PersonDialog.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-dialog v-model="show" max-width="500px">
-    <v-card v-if="show">
+  <v-dialog v-model="dialog" max-width="500px">
+    <v-card v-if="dialog">
       <v-card-title>
         <span class="headline">{{ actionType }} Person</span>
       </v-card-title>
@@ -13,7 +13,7 @@
                 label="Name"
                 autofocus
                 required
-                @keyup.enter="save"
+                @keypress.enter="save"
               />
             </v-flex>
             <v-flex xs12 sm6>
@@ -21,7 +21,7 @@
                 v-model="person.picture"
                 type="url"
                 label="Picture URL"
-                @keyup.enter="save"
+                @keypress.enter="save"
               />
             </v-flex>
           </v-layout>
@@ -33,7 +33,7 @@
           Remove
         </v-btn>
         <v-spacer/>
-        <v-btn color="secondary darken-2" flat @click="show = false">Close</v-btn>
+        <v-btn color="secondary darken-2" flat @click="dialog = false">Close</v-btn>
         <v-btn color="secondary darken-2 dialog-save" flat @click="save">Save</v-btn>
       </v-card-actions>
     </v-card>
@@ -66,7 +66,7 @@ export default {
 
   data () {
     return {
-      show: false,
+      dialog: false,
       confirmRemove: false,
     }
   },
@@ -84,7 +84,7 @@ export default {
   methods: {
     handleKeyPress (event) {
       if (event.keyCode === 13 && this.dialog === true) {
-        this.confirmRemove()
+        this.remove()
       } else if (event.keyCode === 27) {
         this.dialog = false
       }
@@ -93,13 +93,13 @@ export default {
     async save () {
       await this.$store.dispatch('entities/save', Object.assign({ type: 'person' }, this.person))
 
-      this.show = false
+      this.dialog = false
       this.person.name = ''
       this.person.picture = ''
     },
 
     open () {
-      this.show = true
+      this.dialog = true
     },
 
     remove () {

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,4 +1,6 @@
-import firebase from 'firebase'
+import firebase from 'firebase/app'
+import 'firebase/database'
+import 'firebase/auth'
 
 const config = {
   apiKey: process.env.VUE_APP_FIREBASE_API_KEY,

--- a/src/lib/emojis.js
+++ b/src/lib/emojis.js
@@ -3,10 +3,10 @@ export const emojisByName = {
   thumbs_down: '👎',
   heart: '❤️',
   eyes: '👀',
+  rocket: '🚀',
   clock: '🕑',
-  snowman: '⛄',
+  check: '✅',
   party_popper: '🎉',
-  light_bulb: '💡',
 }
 
 export const emojiNames = Object.keys(emojisByName)

--- a/src/lib/emojis.js
+++ b/src/lib/emojis.js
@@ -1,0 +1,12 @@
+export const emojisByName = {
+  thumbs_up: '👍',
+  thumbs_down: '👎',
+  heart: '❤️',
+  eyes: '👀',
+  clock: '🕑',
+  snowman: '⛄',
+  party_popper: '🎉',
+  light_bulb: '💡',
+}
+
+export const emojiNames = Object.keys(emojisByName)

--- a/src/store/shared.js
+++ b/src/store/shared.js
@@ -34,7 +34,7 @@ export default {
       commit('updateNow')
       setInterval(() => {
         commit('updateNow')
-      }, (process.env.NODE_ENV === 'produciton' ? 60 : 5) * 1000)
+      }, (process.env.NODE_ENV === 'production' ? 60 : 5) * 1000)
     },
 
     clearNotification ({ commit }) {

--- a/tests/unit/components/EmojiButton.spec.js
+++ b/tests/unit/components/EmojiButton.spec.js
@@ -1,0 +1,64 @@
+import { shallowMount, createLocalVue, mount } from '@vue/test-utils'
+import Vue from 'vue'
+import Vuetify from 'vuetify'
+import EmojiButton from '@/components/team/EmojiButton'
+
+Vue.use(Vuetify)
+const localVue = createLocalVue()
+
+describe('EmojiButton', () => {
+  it('renders with no exceptions', () => {
+    shallowMount(EmojiButton, {
+      localVue,
+      propsData: { name: 'eyes' },
+    })
+  })
+
+  it('does not show a count by default', () => {
+    const wrapper = shallowMount(EmojiButton, {
+      localVue,
+      propsData: { name: 'eyes' },
+    })
+
+    expect(wrapper.find('.emoji-button__emoji').text()).toEqual('👀')
+    expect(wrapper.find('.emoji-button__count').exists()).toBeFalsy()
+  })
+
+  it('can display a count', () => {
+    const wrapper = shallowMount(EmojiButton, {
+      localVue,
+      propsData: {
+        name: 'eyes',
+        showCount: true,
+        count: 10,
+      },
+    })
+
+    expect(wrapper.find('.emoji-button__emoji').text()).toEqual('👀')
+    expect(wrapper.find('.emoji-button__count').text()).toEqual('10')
+  })
+
+  it('fires an event when clicked', () => {
+    const wrapper = mount(EmojiButton, {
+      localVue,
+      propsData: { name: 'eyes' },
+    })
+
+    wrapper.find('.emoji-button').trigger('click')
+
+    expect(wrapper.emitted('click')).toHaveLength(1)
+    expect(wrapper.emitted('shiftClick')).toBeFalsy()
+  })
+
+  it('fires an event when shift-clicked', () => {
+    const wrapper = mount(EmojiButton, {
+      localVue,
+      propsData: { name: 'eyes' },
+    })
+
+    wrapper.find('.emoji-button').trigger('click', { shiftKey: true })
+
+    expect(wrapper.emitted('shiftClick')).toHaveLength(1)
+    expect(wrapper.emitted('click')).toBeFalsy()
+  })
+})

--- a/tests/unit/components/EmojiPicker.spec.js
+++ b/tests/unit/components/EmojiPicker.spec.js
@@ -1,0 +1,44 @@
+import { shallowMount, createLocalVue, mount } from '@vue/test-utils'
+import Vue from 'vue'
+import Vuetify from 'vuetify'
+import EmojiPicker from '@/components/team/EmojiPicker'
+import EmojiButton from '@/components/team/EmojiButton'
+
+jest.mock('@/lib/emojis', () => ({
+  emojiNames: ['fake_emoji_1', 'fake_emoji_2'],
+  emojisByName: { fake_emoji_1: '👀', fake_emoji_2: '⛄' },
+}))
+
+Vue.use(Vuetify)
+const localVue = createLocalVue()
+
+describe('EmojiPicker', () => {
+  it('renders with no exceptions', () => {
+    shallowMount(EmojiPicker, { localVue })
+  })
+
+  it('renders a button for every emoji', () => {
+    const wrapper = shallowMount(EmojiPicker, { localVue })
+
+    for (const name of ['fake_emoji_1', 'fake_emoji_2']) {
+      const button = wrapper.find({ name })
+      expect(button.is(EmojiButton)).toBeTruthy()
+      expect(button.exists()).toBeTruthy()
+    }
+  })
+
+  it('fires events when emoji buttons are clicked', () => {
+    const wrapper = mount(EmojiPicker, { localVue })
+
+    for (const name of ['fake_emoji_1', 'fake_emoji_2']) {
+      const button = wrapper.find({ name })
+      expect(button.is(EmojiButton)).toBeTruthy()
+      button.trigger('click')
+    }
+
+    expect(wrapper.emitted('pick')).toEqual([
+      ['fake_emoji_1'],
+      ['fake_emoji_2'],
+    ])
+  })
+})


### PR DESCRIPTION
This change lets users add reactions to list items. It adds a button to the left of the delete-list-item button that pops up a menu where you can select an emoji.

When an item has emojis, they are listed underneath the item text with a count of the reactions (a-la Slack). Clicking on these buttons increments the count, and shift-clicking decrements the count.

The implemented emojis are:
👍 👎 ❤️ 👀 🚀 🕑 ✅ 🎉

I kept it simple and inspired by the reactions on GitHub comments/Pivotal Tracker comments. But if you'd prefer, I can add/change the emojis (see `emojis.js` - we can just tweak that list). Or, I could do something more complex, like add all Unicode emojis with a search bar. (Something like this? https://github.com/DCzajkowski/vue-emoji-picker) But I didn't see the need for now.

If you'd like me to tweak it in any way (different emojis? more tests?) before merging, just let me know.

And if you don't want to merge this, that's fine! It was a feature my team talked about, but we don't really need it. I mainly wanted to get familiar with the codebase and Vue.

Note that there are a few other changes here (got rid of some deprecation warnings that were showing up in the console). I'm happy to remove those or put those in a separate PR if you'd prefer.

Here's a GIF that demonstrates the feature:

![emoji reaction demo GIF](https://user-images.githubusercontent.com/6752783/63646236-3cf3a180-c6c4-11e9-9a64-3e8f0c993694.gif)
