### PR TITLE
style: change emoji buttons styling

### DIFF
--- a/src/components/team/EmojiButton.vue
+++ b/src/components/team/EmojiButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-btn icon ripple class="emoji-button" @click="handleClick">
+  <v-btn flat ripple class="emoji-button" @click="handleClick">
     <span class="emoji-button__emoji">{{ emojisByName[this.$props.name] }}</span>
     <span v-if="showCount" class="emoji-button__count primary--text">{{ this.$props.count }}</span>
   </v-btn>
@@ -42,12 +42,15 @@ export default {
 <style lang="stylus">
 .emoji-button
   margin: 0
+  padding: 0.25em 0.5em
+  min-width: auto
   font-style: normal
   font-weight: normal
 
   .emoji-button__emoji
     font-size: 1.2em
     width: 1.1em
+    margin-right: 6px
 
   .emoji-button__count
     font-size: 0.9em

--- a/src/components/team/ListItem.vue
+++ b/src/components/team/ListItem.vue
@@ -192,6 +192,4 @@ export default {
     list-style-type: none
     display: inline-block
 
-  .emoji-list__item + .emoji-list__item
-    margin-left: 8px
 </style>


### PR DESCRIPTION
The current emoji buttons look not organized and out of order. This PR makes them square (like in GitHub) and fixes their alignment.

_Before_
![Screen Shot 2019-08-30 at 9 45 54 AM](https://user-images.githubusercontent.com/3942554/64037766-52752b00-cb0b-11e9-9f2e-14286035fd00.png)

_After_
![Screen Shot 2019-08-30 at 9 45 21 AM](https://user-images.githubusercontent.com/3942554/64037780-586b0c00-cb0b-11e9-9cf5-26856a7d14a2.png)

