### PR TITLE
ux: add help text for removing emojis

### DIFF
--- a/src/components/team/EmojiButton.vue
+++ b/src/components/team/EmojiButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-btn flat ripple class="emoji-button" @click="handleClick">
+  <v-btn flat ripple class="emoji-button" title="Shift-Click to remove emoji" @click="handleClick">
     <span class="emoji-button__emoji">{{ emojisByName[this.$props.name] }}</span>
     <span v-if="showCount" class="emoji-button__count primary--text">{{ this.$props.count }}</span>
   </v-btn>


### PR DESCRIPTION
I had trouble figuring out how to remove emojis that were added accidentally until I looked at the code and noticed the `shiftClick` handler. Figured we could use some low-key title text to help folks out here!

![Screen Shot 2019-10-01 at 9 58 12 PM](https://user-images.githubusercontent.com/2096955/66019091-aa021000-e496-11e9-9c04-f7628cfb438d.png)

**p.s.** let me know if you want a PR for that premium moon emoji 🌝 (bcc @AnthonyRoss)