### PR TITLE
Unlock people when moving into a lane

### DIFF
--- a/src/actions/person.ts
+++ b/src/actions/person.ts
@@ -3,12 +3,21 @@ import { db } from '../firebase';
 const teamsRef = db.collection('teams');
 
 export async function movePersonToLane(teamId: string, userId: string, laneId: string) {
-  await teamsRef.doc(teamId).collection('people').doc(userId).set(
-    {
-      laneId,
-    },
-    { merge: true }
-  );
+  const newSettings: {
+    laneId: string;
+    isLocked?: boolean;
+  } = {
+    laneId,
+  };
+
+  if (laneId) {
+    // We only want to update this field when we are moving this person into an
+    // actual lane. And if we're moving this person to a lane, we know they should
+    // not be considered locked anymore.
+    newSettings.isLocked = false;
+  }
+
+  await teamsRef.doc(teamId).collection('people').doc(userId).set(newSettings, { merge: true });
 }
 
 export async function lockPerson(teamId: string, userId: string) {


### PR DESCRIPTION
We (relatively) recently added the feature where you can lock a person
by dragging them into the "locked" section of the "People" box on the
right. Doing this changes the person's `isLocked` property in the
database.

But we then allow the person to be dragged manually into a lane. When
this happens, we were not updating the `isLocked` property on the
person. This could be seen when sweeping a formerly-locked person out of
their lane: they would return to the "People" box in the locked state.

This also affected the recommendation logic:
https://github.com/pivotal-cf/pairist/blob/8f4ca005ecfec50f26377cc6f3961f993256b792/src/lib/adapter.ts#L54

That line means any people with `isLocked: true` would be considered
"out" (unavailable for pairing) for the purposes of the recommendation
engine. That throws things off, which is very unexpected if you've just
dragged the person into a lane and expect them to be paired.

We're fixing this by just updating the `isLocked` property to `true`
whenever we move a person into a lane. The logic here is a little tricky
because we don't want to just to `isLocked: !!laneId` - that would set
`isLocked` to true whenever we move a person out of a lane.