### PR TITLE
Fix width on mobile devices

### DIFF
--- a/src/components/Entities.tsx
+++ b/src/components/Entities.tsx
@@ -180,6 +180,7 @@ const styles = css`
     @media screen and (max-width: $breakpoint) {
       height: initial;
       display: block;
+      max-width: 100%;
     }
   }
 

--- a/src/components/Lists.tsx
+++ b/src/components/Lists.tsx
@@ -100,6 +100,7 @@ const styles = css`
 
     @media screen and (max-width: $breakpoint) {
       display: block;
+      max-width: 100%;
     }
   }
 

--- a/src/components/Pairs.tsx
+++ b/src/components/Pairs.tsx
@@ -143,6 +143,7 @@ const styles = css`
 
     @media screen and (max-width: $breakpoint) {
       order: 99;
+      max-width: 100%;
     }
   }
 


### PR DESCRIPTION
On mobile devices, columns are arranged vertically as expected, but only 1/3 of the screen wide. This PR overrides this behavior for mobile screens.